### PR TITLE
Fixed Wild Card Function

### DIFF
--- a/server.js
+++ b/server.js
@@ -373,7 +373,7 @@ function onConnection(socket) {
       let boardColor = cardColor(data[res[1]]['cardOnBoard']);
       let boardNumber = data[res[1]]['cardOnBoard'] % 14;
 
-      if (playedColor === 'black' || playedColor === boardColor || playedNumber === boardNumber) {
+      if (playedColor === 'black' || playedColor === boardColor || playedNumber === boardNumber || boardColor === 'black') {
         // Play card
         io.to(res[1]).emit('sendCard', res[0]);
         data[res[1]]['cardOnBoard'] = res[0];


### PR DESCRIPTION
This PR changes this Uno game by enabling users to be able to continue playing regular cards after playing the Wild Card instead of the game only letting the user draw cards or play Wild Cards after it is played.

This matters because before this improvement, users would have no way to win the game because if they ever played a Wild Card, they wouldn't be able to play any other cards but Wild Cards after that. 

I verified this change by playing a Wild Card in the game, and then seeing if I was able to play another number card after that. I expected to be able to play the game normally after I implemented my improvement. I observed that my test worked, and I was able to continue playing the game after playing the Wild Card. 

Here is a screen recording that proves this change works:

https://github.com/user-attachments/assets/c32752ef-bf4d-4cf9-a0ca-0886f67a09bd

This PR is ready for review.
